### PR TITLE
Bump System.Text.RegularExpressions from 4.3.0 to 4.3.1 in /Kudu.Core

### DIFF
--- a/Kudu.Core/Kudu.Core.csproj
+++ b/Kudu.Core/Kudu.Core.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Mercurial.Net" Version="1.1.1.607" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Azure.WebSites.DataProtection" Version="0.1.78-alpha" />
     <PackageReference Include="ncrontab" Version="3.3.0" />


### PR DESCRIPTION
Bumps System.Text.RegularExpressions from 4.3.0 to 4.3.1.

---
updated-dependencies:
- dependency-name: System.Text.RegularExpressions
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>